### PR TITLE
fromLinks add missing param to loadSingle call

### DIFF
--- a/src/load/fromLinks.js
+++ b/src/load/fromLinks.js
@@ -29,7 +29,7 @@ define([
 			links.forEach( function ( link ) {
 				var name = getNameFromLink( link );
 
-				loadSingle( link.getAttribute( 'href' ), baseUrl, cache ).then( function ( Component ) {
+				loadSingle( link.getAttribute( 'href' ), '', baseUrl, cache ).then( function ( Component ) {
 					Ractive.components[ name ] = Component;
 
 					if ( !--pending ) {

--- a/src/load/single.js
+++ b/src/load/single.js
@@ -36,7 +36,7 @@ define([
 							// if import has a relative URL, it should resolve
 							// relative to this (parent). Otherwise, relative
 							// to load.baseUrl
-							loadSingle( path, parentUrl, baseUrl ).then( callback, reject );
+							loadSingle( path, parentUrl, baseUrl, cache ).then( callback, reject );
 						},
 						require: ractiveRequire
 					}, fulfil, reject );


### PR DESCRIPTION
Attempt to address #7. Not really sure if this is right thing to do, but loading fromLinks doesn't work otherwise (I'm I the only one loading from links? What are all the kool kids using, AMD?)

Also passed along cache parameter in other instance @MartinKolarik mentioned. 

Not as familiar with this code, so would appreciate someone chiming in.
