### PR TITLE
Update to rcu 0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "jsnext:main": "dist/ractive-load.es.js",
   "description": "Component loader plugin for Ractive.js",
   "dependencies": {
-    "rcu": "^0.4.0"
+    "rcu": "^0.8.0"
   },
   "devDependencies": {
     "eslint": "^2.11.1",

--- a/src/load.js
+++ b/src/load.js
@@ -1,5 +1,5 @@
 import Ractive from 'ractive';
-import rcu from 'rcu';
+import * as rcu from 'rcu';
 import loadFromLinks from './load/fromLinks';
 import loadSingle from './load/single';
 import loadMultiple from './load/multiple';

--- a/src/load/fromLinks.js
+++ b/src/load/fromLinks.js
@@ -1,5 +1,5 @@
 import Ractive from 'ractive';
-import rcu from 'rcu';
+import * as rcu from 'rcu';
 import loadSingle from './single';
 
 // Create globally-available components from links found on the page:

--- a/src/load/single.js
+++ b/src/load/single.js
@@ -1,5 +1,5 @@
 import Ractive from 'ractive';
-import rcu from 'rcu';
+import * as rcu from 'rcu';
 import get from '../utils/get';
 import load from '../load';
 


### PR DESCRIPTION
Hi guys.
I'm waiting for rcu to release next version that includes [handling of the breaking change to the templates API](https://github.com/ractivejs/rcu/pull/27#issuecomment-225897334) and did this locally for now, so might as well share this, since it also needed a minor code change.

As soon as a version that includes the fix is released, please rebuild this and update the 'dist' folder, as this will allow Ractive.load to work with the edge again.
