### PR TITLE
Fix `npm install` on Windows throwing "Expected linebreaks to be 'LF'but found 'CRLF'"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Use Unix EOLs by default even on Windows because the linebreak-style in .eslintrc can't be made dynamic like the Window's default git behavior
+* text=auto eol=lf


### PR DESCRIPTION
… from eslint

This applies the same fix as https://github.com/ractivejs/rcu/pull/29

Fix by using the [per repository .gitattributes overrides](https://help.github.com/articles/dealing-with-line-endings/#per-repository-settings)

Rationale: The Windows' default is 'auto', which will result in checking out CRLF and, as a result, eslint complaining.

Since eslint is being used and its [linebreak-style](http://eslint.org/docs/rules/linebreak-style) can't be dynamic to say CRLF when checking under windows, this is the only real option.

Windows editors support Unix EOLs just fine, so this should really be OK. The worst that can happen is someone that didn't rebuild commits Windows EOLs in his fork, which will get caught by the eslint checks on the pull requests.
